### PR TITLE
go.mod: remove version restriction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,5 @@
 module github.com/nokibsarkar/campwiz-test
 
-// +heroku goVersion go1.21.5
 go 1.24.1
 
 require (


### PR DESCRIPTION
Toolforge now support golang 1.24